### PR TITLE
GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/push_to_itch.yml
+++ b/.github/workflows/push_to_itch.yml
@@ -2,8 +2,10 @@ name: Push to Itch
 
 on:
   push:
-    branches:
-      - master
+    branches:    
+      - pipeline/*
+    tags:
+      - v*.*.*
 
 jobs:
   godot:
@@ -17,10 +19,12 @@ jobs:
       - name: Configure
         env:
           PLATFORM: ${{ matrix.platform }}
+          GITHUB_REF: ${{ github.head_ref }}
         run: |
           if [ "$PLATFORM" = "win32" ] || [ "$PLATFORM" = "win64" ]; then
             echo "::set-env name=EXPORT_SUFFIX::.exe"
           fi
+          echo ${GITHUB_REF##*/} > VERSION.txt
           echo "Trigger build!"
       - name: Build Godot Project
         uses: josephbmanley/build-godot-action@v1.4.0
@@ -37,3 +41,4 @@ jobs:
           ITCH_USER: pigdev
           PACKAGE: ${{ github.workspace }}/${{ steps.godot_build.outputs.build }}
           BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          VERSION_FILE: VERSION.txt


### PR DESCRIPTION
Triggers:
- Push to any branch begining with `pipline/`. This is to allow for pipeline development environments.
- Tagged pushed following convention `v*.*.*` so `v1.0.0` or `v2.5.71`

### Godot Job

    Matrix `platform` is export present names. The job will run for each export

#### Notable Changes to Steps

##### Configure

- Writes ref to `VERSION.txt` file.

##### Push to Itch

- Read version from `VERSION.txt`
